### PR TITLE
Fix field name dots

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/serialization/ScrollReader.java
@@ -1052,8 +1052,11 @@ public class ScrollReader implements Closeable {
             else {
                 reader.beginField(absoluteName);
 
-                // Must point to field name
-                Object fieldName = reader.readValue(parser, currentName, FieldType.STRING);
+                // Replace any dots in the field name with underscores to avoid
+                // nested map structures being created unintentionally when
+                // a field name legitimately contains dots.
+                String sanitized = currentName.replace('.', '_');
+                Object fieldName = reader.readValue(parser, sanitized, FieldType.STRING);
                 // And then the value...
                 reader.addToMap(map, fieldName, read(absoluteName, parser.nextToken(), nodeMapping, parser));
                 reader.endField(absoluteName);


### PR DESCRIPTION
## Summary
- sanitize field names when parsing scroll hits

## Testing
- `./gradlew test` *(fails: `$JAVA8_HOME` not set)*

------
https://chatgpt.com/codex/tasks/task_b_688a0455e06c8330a2664e4f093c3a46